### PR TITLE
Switch to a real application for testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,35 +5,27 @@ from unittest import mock
 
 from aioamqp.envelope import Envelope
 from aioamqp.properties import Properties
+from henson import Application
 import pytest
 
 from henson_amqp import AMQP
 
 
-class Application:
-    """A stub application that can be used for testing.
+class Settings:
+    """A container object for test settings."""
 
-    Args:
-        **settings: Keyword arguments that will be used as settings.
-    """
-
-    def __init__(self, **settings):
-        """Initialize the instance."""
-        self.name = 'testing'
-        self.settings = settings
+    AMQP_HOST = os.environ.get('TEST_AMQP_HOST', 'localhost')
+    AMQP_QUEUE_INBOUND = 'test.in'
+    AMQP_EXCHANGE_INBOUND = 'test.in'
+    AMQP_EXCHANGE_OUTBOUND = 'test.in'
+    AMQP_ROUTING_KEY_INBOUND = 'test.in'
+    AMQP_ROUTING_KEY_OUTBOUND = 'test.in'
 
 
 @pytest.fixture
 def test_amqp():
     """Return an extension bound to the test app."""
-    app = Application(
-        AMQP_HOST=os.environ.get('TEST_AMQP_HOST', 'localhost'),
-        AMQP_QUEUE_INBOUND='test.in',
-        AMQP_EXCHANGE_INBOUND='test.in',
-        AMQP_EXCHANGE_OUTBOUND='test.in',
-        AMQP_ROUTING_KEY_INBOUND='test.in',
-        AMQP_ROUTING_KEY_OUTBOUND='test.in',
-    )
+    app = Application('testing', Settings)
     return AMQP(app)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 [testenv:pep8]
 basepython = python3.5
 deps =
-    flake8-docstrings
+    flake8-docstrings==0.2.1.post1
     pep8-naming
 commands =
     flake8 henson_amqp


### PR DESCRIPTION
As Henson-AMQP uses more features of Henson, mocking away the
Application class become less useful. Switching to a real application
with fake settings reduces the need to duplicate the behavior of
`henson.Application` in a test class.

Additionally, lock flake8-docstrings in tox to a working version.
