### PR TITLE
Update teardown callback name

### DIFF
--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -37,7 +37,7 @@ class Consumer:
         # Register the message acknowledgement and application teardown
         # callbacks with the application.
         self.app.message_acknowledgement(self.acknowledge_message)
-        self.app.application_teardown(self.teardown)
+        self.app.teardown(self.teardown)
 
     @asyncio.coroutine
     def acknowledge_message(self, app, message):
@@ -146,7 +146,7 @@ class Producer:
         self.protocol = None
 
         # Register a teardown callback.
-        self.app.application_teardown(self.teardown)
+        self.app.teardown(self.teardown)
 
     @asyncio.coroutine
     def teardown(self, app):


### PR DESCRIPTION
Henson's application teardown callback registration function has changed
its name from `application_teardown` to simply `teardown`. This
change brings Henson-AMQP up to date with Henson.
