### PR TITLE
Cache producers to reuse rabbit connections

### DIFF
--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -233,11 +233,13 @@ class AMQP(Extension):
         return Consumer(self.app)
 
     def producer(self):
-        """Return a new AMQP producer.
+        """Return an AMQP producer, creating it if necessary.
 
         Returns:
             Producer: A new producer object that can be used to write to
                 the AMQP broker and exchange specified by the
                 Application's settings.
         """
-        return Producer(self.app)
+        if not hasattr(self, '_producer'):
+            self._producer = Producer(self.app)
+        return self._producer

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,6 +1,7 @@
 """henson_amqp unit tests."""
 
 import asyncio
+from copy import copy
 from unittest import mock
 
 import pytest
@@ -32,3 +33,18 @@ def test_read(test_consumer, test_envelope, test_properties):
     test_consumer._message_queue.put_nowait(message)
     read_message = (yield from test_consumer.read())
     assert read_message == message
+
+
+def test_producer_factory(test_amqp):
+    """Test that ``AMQP.producer`` caches its result."""
+    producer1 = test_amqp.producer()
+    producer2 = test_amqp.producer()
+    assert producer1 is producer2
+
+
+def test_different_producer_factories(test_amqp):
+    """Test that different AMQP instances return different producers."""
+    test_amqp_copy = copy(test_amqp)
+    producer1 = test_amqp.producer()
+    producer2 = test_amqp_copy.producer()
+    assert producer1 is not producer2


### PR DESCRIPTION
Currently, producers are created each time a message needs to be sent.
The connections created by these producers are not torn down until the
application's teardown step immediately prior to halting, so the
connection count continues to increase. Caching the producer being used
should prevent this from happening.
