### PR TITLE
Set limit for the number of messages to prefetch

### DIFF
--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -83,7 +83,8 @@ class Consumer:
     def _begin_consuming(self):
         """Begin reading messages from the specified AMQP broker."""
         # Create a connection to the broker
-        self._message_queue = asyncio.Queue()
+        self._message_queue = asyncio.Queue(
+            maxsize=self.app.settings['AMQP_PREFETCH_LIMIT'])
         self._transport, self._protocol = yield from aioamqp.connect(
             host=self.app.settings['AMQP_HOST'],
             port=self.app.settings['AMQP_PORT'],
@@ -205,6 +206,9 @@ class AMQP(Extension):
     """An interface to interact with an AMQP broker."""
 
     DEFAULT_SETTINGS = {
+        # General settings
+        'AMQP_PREFETCH_LIMIT': 0,
+
         # Connection settings
         'AMQP_HOST': 'localhost',
         'AMQP_PORT': 5672,


### PR DESCRIPTION
Currently, the AMQP extension will prefetch as many messages as
possible. This is undesirable in some cases, so a configurable limit is
being introduced.
