### PR TITLE
Let tox install the newest flake8-docstrings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 [testenv:pep8]
 basepython = python3.5
 deps =
-    flake8-docstrings==0.2.1.post1
+    flake8-docstrings
     pep8-naming
 commands =
     flake8 henson_amqp


### PR DESCRIPTION
A regression was introduced in flake8-docstrings 0.2.2 that required a
blank line before a class's docstring. Version 0.2.5 fixes this.