### PR TITLE
Raise an exception when aioamqp closes a connection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Version 0.2.0
 
 Release TBD
 
+- If a connection is closed by ``aioamqp`` while reading, raise that exception
+  during calls to ``Consumer.read`` after all previously read messages have
+  been returned.
+
 
 Version 0.1.0
 =============

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -1,0 +1,18 @@
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+def test_disconnect_consumer(test_consumer):
+    """Test disconnect logic for consumers."""
+    test_consumer._message_queue = asyncio.Queue()
+    test_consumer._message_queue.put_nowait('message')
+    test_consumer._message_queue.put_nowait('message')
+    test_consumer._message_queue.put_nowait('message')
+    yield from test_consumer._connection_error_callback(Exception())
+    for i in range(3):
+        message = yield from test_consumer.read()
+        assert message == 'message'
+    with pytest.raises(Exception):
+        yield from test_consumer.read()


### PR DESCRIPTION
When a connection to the AMQP server is closed, the ``read`` coroutine
now reraises the exception that was raised as a result of the connection
closing. If messages have already been read into the internal message
queue, these are returned before raising.