### PR TITLE
Add support for automatically registering a consumer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.3.0
 Release TBD
 
 - Add support for ``Retry``
+- Add ``REGISTER_CONSUMER`` setting
 
 
 Version 0.2.0

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -33,32 +33,36 @@ Connection Settings
 Consumer Settings
 =================
 
-+------------------------------------+----------------------------------------+
-| ``AMQP_INBOUND_EXCHANGE``          | The name of the exchange that the      |
-|                                    | consumer should read from. Defaults to |
-|                                    | ``''`` (the AMQP default exchange).    |
-+------------------------------------+----------------------------------------+
-| ``AMQP_INBOUND_EXCHANGE_DURABLE``  | The durability setting of the exchange |
-|                                    | that the consumer reads from. Defaults |
-|                                    | to ``False``.                          |
-+------------------------------------+----------------------------------------+
-| ``AMQP_INBOUND_EXCHANGE_TYPE``     | The type of the inbound exchange.      |
-|                                    | Defaults to ``'direct'``.              |
-+------------------------------------+----------------------------------------+
-| ``AMQP_INBOUND_QUEUE``             | The name of the queue that the         |
-|                                    | consumer should read from. Defaults to |
-|                                    | ``''`` (the AMQP default queue).       |
-+------------------------------------+----------------------------------------+
-| ``AMQP_INBOUND_QUEUE_DURABLE``     | The durability setting of the queue    |
-|                                    | the consumer reads from. Defaults to   |
-|                                    | ``False``.                             |
-+------------------------------------+----------------------------------------+
-| ``AMQP_INBOUND_ROUTING_KEY``       | The routing key used to bind the       |
-|                                    | inbound exchange and queue. Defaults   |
-|                                    | to ``''``.                             |
-+------------------------------------+----------------------------------------+
-| ``AMQP_DISPATCH_METHOD``           | Reserved for future use.               |
-+------------------------------------+----------------------------------------+
++-----------------------------------+-----------------------------------------+
+| ``REGISTER_CONSUMER``             | If ``True``, a consumer will be         |
+|                                   | automatically created and assigned to   |
+|                                   | the application. Defaults to ``False``. |
++-----------------------------------+-----------------------------------------+
+| ``AMQP_INBOUND_EXCHANGE``         | The name of the exchange that the       |
+|                                   | consumer should read from. Defaults to  |
+|                                   | ``''`` (the AMQP default exchange).     |
++-----------------------------------+-----------------------------------------+
+| ``AMQP_INBOUND_EXCHANGE_DURABLE`` | The durability setting of the exchange  |
+|                                   | that the consumer reads from. Defaults  |
+|                                   | to ``False``.                           |
++-----------------------------------+-----------------------------------------+
+| ``AMQP_INBOUND_EXCHANGE_TYPE``    | The type of the inbound exchange.       |
+|                                   | Defaults to ``'direct'``.               |
++-----------------------------------+-----------------------------------------+
+| ``AMQP_INBOUND_QUEUE``            | The name of the queue that the          |
+|                                   | consumer should read from. Defaults to  |
+|                                   | ``''`` (the AMQP default queue).        |
++-----------------------------------+-----------------------------------------+
+| ``AMQP_INBOUND_QUEUE_DURABLE``    | The durability setting of the queue     |
+|                                   | the consumer reads from. Defaults to    |
+|                                   | ``False``.                              |
++-----------------------------------+-----------------------------------------+
+| ``AMQP_INBOUND_ROUTING_KEY``      | The routing key used to bind the        |
+|                                   | inbound exchange and queue. Defaults    |
+|                                   | to ``''``.                              |
++-----------------------------------+-----------------------------------------+
+| ``AMQP_DISPATCH_METHOD``          | Reserved for future use.                |
++-----------------------------------+-----------------------------------------+
 
 Producer Settings
 =================

--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -293,6 +293,7 @@ class AMQP(Extension):
         'AMQP_CONNECTION_KWARGS': {},
 
         # Consumer settings
+        'REGISTER_CONSUMER': False,
         'AMQP_DISPATCH_METHOD': 'ROUND_ROBIN',
         'AMQP_INBOUND_EXCHANGE': '',
         'AMQP_INBOUND_EXCHANGE_DURABLE': False,
@@ -309,6 +310,20 @@ class AMQP(Extension):
         'AMQP_OUTBOUND_ROUTING_KEY': '',
         'AMQP_DELIVERY_MODE': DeliveryMode.NONPERSISTENT,
     }
+
+    def init_app(self, app):
+        """Initialize the application.
+
+        If the application's ``REGISTER_CONSUMER`` setting is truthy,
+        create a consumer and attach it to the application.
+
+        Args:
+            app (henson.base.Application): The application instance that
+                will be initialized.
+        """
+        super().init_app(app)
+        if app.settings['REGISTER_CONSUMER']:
+            app.consumer = self.consumer()
 
     def consumer(self):
         """Return a new AMQP consumer.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,15 @@ class Settings:
 
 
 @pytest.fixture
-def test_amqp():
+def test_app():
+    """Return a test application."""
+    return Application('testing', Settings)
+
+
+@pytest.fixture
+def test_amqp(test_app):
     """Return an extension bound to the test app."""
-    app = Application('testing', Settings)
-    return AMQP(app)
+    return AMQP(test_app)
 
 
 @pytest.fixture

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7,7 +7,20 @@ from unittest import mock
 
 import pytest
 
-from henson_amqp import Message
+from henson_amqp import AMQP, Consumer, Message
+
+
+def test_register_consumer(test_app):
+    """Test that consumer registration behaves correctly."""
+    test_app.settings['REGISTER_CONSUMER'] = True
+    AMQP(test_app)
+    assert isinstance(test_app.consumer, Consumer)
+
+
+def test_no_register_consumer(test_app):
+    """Test that consumers are not registered if not explicitly set."""
+    AMQP(test_app)
+    assert not test_app.consumer
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
In most use cases, Henson-AMQP is being used for its ``Consumer`` and
``Producer`` classes. Currently, Henson applications using this
``Consumer`` class require boilerplate to create and assign a consumer.
This change reduces that boilerplate to a setting.

Initially, this feature is disabled by default to prevent existing
applications from inadvertently creating multiple consumers after
upgrading to a new release of Henson-AMQP. In the future, if widely
used, it may become enabled by default.