### PR TITLE
Add support for specifying routing key when sending

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Version 0.4.0
 
 Release TBD
 
+- Allow callers of ``Producer.send`` to specify a routing key
+
 
 Version 0.3.0
 =============

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -78,9 +78,10 @@ Producer Settings
 | ``AMQP_OUTBOUND_EXCHANGE_TYPE``    | The type of the outbound exchange.             |
 |                                    | Defaults to ``'direct'``.                      |
 +------------------------------------+------------------------------------------------+
-| ``AMQP_OUTBOUND_ROUTING_KEY``      | The routing key used when sending              |
-|                                    | messages to the outbound exchange.             |
-|                                    | Defaults to ``''``.                            |
+| ``AMQP_OUTBOUND_ROUTING_KEY``      | The default routing key used when              |
+|                                    | sending messages to the outbound               |
+|                                    | exchange if the ``routing_key`` argument       |
+|                                    | is not provided. Defaults to ``''``.           |
 +------------------------------------+------------------------------------------------+
 | ``AMQP_PREFETCH_LIMIT``            | The maximum number of messages to keep         |
 |                                    | in the internal queue waiting to be            |

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -62,6 +62,37 @@ def test_retry(test_consumer):
     )
 
 
+@pytest.mark.asyncio
+def test_produce_routing_key(test_producer):
+    """Test that providing a routing key when sending works."""
+    test_producer._channel = mock.MagicMock()
+    message = 'spam and eggs'
+    routing_key = 'parrot'
+
+    yield from test_producer.send(message, routing_key=routing_key)
+    test_producer._channel.publish.assert_called_with(
+        payload=message,
+        routing_key=routing_key,
+        exchange_name=mock.ANY,
+        properties=mock.ANY,
+    )
+
+
+@pytest.mark.asyncio
+def test_produce_no_routing_key(test_producer):
+    """Test that a default routing key is used when none is provided."""
+    test_producer._channel = mock.MagicMock()
+    message = 'spam and eggs'
+    yield from test_producer.send(message)
+
+    test_producer._channel.publish.assert_called_with(
+        payload=message,
+        routing_key=test_producer.app.settings['AMQP_OUTBOUND_ROUTING_KEY'],
+        exchange_name=mock.ANY,
+        properties=mock.ANY,
+    )
+
+
 def test_producer_factory(test_amqp):
     """Test that ``AMQP.producer`` caches its result."""
     producer1 = test_amqp.producer()


### PR DESCRIPTION
Currently, all messages sent via a Henson-AMQP Producer instance use the
same routing key (specified by an application setting). Outside of very
simple cases and fanout exchanges, this is inflexible. This change
allows routing keys to be used when sending messages to the AMQP
exchange and retains full backward compatibility by defaulting to the
application setting when a routing key is not included in the function
call arguments.

Note: In the future, changing the setting's name from
``AMQP_OUTBOUND_ROUTING_KEY`` to ``AMQP_DEFAULT_OUTBOUND_ROUTING_KEY``
may be more descriptive (though it is more verbose, as well).