### PR TITLE
Add Exchange Declaration Arguments

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -33,36 +33,40 @@ Connection Settings
 Consumer Settings
 =================
 
-+-----------------------------------+-----------------------------------------+
-| ``REGISTER_CONSUMER``             | If ``True``, a consumer will be         |
-|                                   | automatically created and assigned to   |
-|                                   | the application. Defaults to ``False``. |
-+-----------------------------------+-----------------------------------------+
-| ``AMQP_INBOUND_EXCHANGE``         | The name of the exchange that the       |
-|                                   | consumer should read from. Defaults to  |
-|                                   | ``''`` (the AMQP default exchange).     |
-+-----------------------------------+-----------------------------------------+
-| ``AMQP_INBOUND_EXCHANGE_DURABLE`` | The durability setting of the exchange  |
-|                                   | that the consumer reads from. Defaults  |
-|                                   | to ``False``.                           |
-+-----------------------------------+-----------------------------------------+
-| ``AMQP_INBOUND_EXCHANGE_TYPE``    | The type of the inbound exchange.       |
-|                                   | Defaults to ``'direct'``.               |
-+-----------------------------------+-----------------------------------------+
-| ``AMQP_INBOUND_QUEUE``            | The name of the queue that the          |
-|                                   | consumer should read from. Defaults to  |
-|                                   | ``''`` (the AMQP default queue).        |
-+-----------------------------------+-----------------------------------------+
-| ``AMQP_INBOUND_QUEUE_DURABLE``    | The durability setting of the queue     |
-|                                   | the consumer reads from. Defaults to    |
-|                                   | ``False``.                              |
-+-----------------------------------+-----------------------------------------+
-| ``AMQP_INBOUND_ROUTING_KEY``      | The routing key used to bind the        |
-|                                   | inbound exchange and queue. Defaults    |
-|                                   | to ``''``.                              |
-+-----------------------------------+-----------------------------------------+
-| ``AMQP_DISPATCH_METHOD``          | Reserved for future use.                |
-+-----------------------------------+-----------------------------------------+
++-----------------------------------+-------------------------------------------+
+| ``REGISTER_CONSUMER``             | If ``True``, a consumer will be           |
+|                                   | automatically created and assigned to     |
+|                                   | the application. Defaults to ``False``.   |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_INBOUND_EXCHANGE``         | The name of the exchange that the         |
+|                                   | consumer should read from. Defaults to    |
+|                                   | ``''`` (the AMQP default exchange).       |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_INBOUND_EXCHANGE_DURABLE`` | The durability setting of the exchange    |
+|                                   | that the consumer reads from. Defaults    |
+|                                   | to ``False``.                             |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_INBOUND_EXCHANGE_TYPE``    | The type of the inbound exchange.         |
+|                                   | Defaults to ``'direct'``.                 |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_INBOUND_EXCHANGE_KWARGS``  | Additonal arguments to pass to            |
+|                                   | :func:`aioamqp.channel.exchange_declare`. |
+|                                   | Defaults to ``{}``.                       |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_INBOUND_QUEUE``            | The name of the queue that the            |
+|                                   | consumer should read from. Defaults to    |
+|                                   | ``''`` (the AMQP default queue).          |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_INBOUND_QUEUE_DURABLE``    | The durability setting of the queue       |
+|                                   | the consumer reads from. Defaults to      |
+|                                   | ``False``.                                |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_INBOUND_ROUTING_KEY``      | The routing key used to bind the          |
+|                                   | inbound exchange and queue. Defaults      |
+|                                   | to ``''``.                                |
++-----------------------------------+-------------------------------------------+
+| ``AMQP_DISPATCH_METHOD``          | Reserved for future use.                  |
++-----------------------------------+-------------------------------------------+
 
 Producer Settings
 =================
@@ -77,6 +81,10 @@ Producer Settings
 +------------------------------------+------------------------------------------------+
 | ``AMQP_OUTBOUND_EXCHANGE_TYPE``    | The type of the outbound exchange.             |
 |                                    | Defaults to ``'direct'``.                      |
++------------------------------------+------------------------------------------------+
+| ``AMQP_OUTBOUND_EXCHANGE_KWARGS``  | Additonal arguments to pass to                 |
+|                                    | :func:`aioamqp.channel.exchange_declare`.      |
+|                                    | Defaults to ``{}``.                            |
 +------------------------------------+------------------------------------------------+
 | ``AMQP_OUTBOUND_ROUTING_KEY``      | The default routing key used when              |
 |                                    | sending messages to the outbound               |

--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -128,6 +128,7 @@ class Consumer:
         )
         if self.app.settings['AMQP_INBOUND_EXCHANGE']:
             yield from self._channel.exchange_declare(
+                arguments=self.app.settings['AMQP_INBOUND_EXCHANGE_KWARGS'],
                 durable=self.app.settings['AMQP_INBOUND_EXCHANGE_DURABLE'],
                 exchange_name=self.app.settings['AMQP_INBOUND_EXCHANGE'],
                 type_name=self.app.settings['AMQP_INBOUND_EXCHANGE_TYPE'],
@@ -265,6 +266,7 @@ class Producer:
             routing_key = self.app.settings['AMQP_OUTBOUND_ROUTING_KEY']
 
         yield from self._channel.exchange_declare(
+            arguments=self.app.settings['AMQP_OUTBOUND_EXCHANGE_KWARGS'],
             durable=self.app.settings['AMQP_OUTBOUND_EXCHANGE_DURABLE'],
             exchange_name=self.app.settings['AMQP_OUTBOUND_EXCHANGE'],
             type_name=self.app.settings['AMQP_OUTBOUND_EXCHANGE_TYPE'],
@@ -305,6 +307,7 @@ class AMQP(Extension):
         'AMQP_INBOUND_EXCHANGE': '',
         'AMQP_INBOUND_EXCHANGE_DURABLE': False,
         'AMQP_INBOUND_EXCHANGE_TYPE': 'direct',
+        'AMQP_INBOUND_EXCHANGE_KWARGS': {},
         'AMQP_INBOUND_QUEUE': '',
         'AMQP_INBOUND_QUEUE_DURABLE': False,
         'AMQP_INBOUND_ROUTING_KEY': '',
@@ -314,6 +317,7 @@ class AMQP(Extension):
         'AMQP_OUTBOUND_EXCHANGE': '',
         'AMQP_OUTBOUND_EXCHANGE_DURABLE': False,
         'AMQP_OUTBOUND_EXCHANGE_TYPE': 'direct',
+        'AMQP_OUTBOUND_EXCHANGE_KWARGS': {},
         'AMQP_OUTBOUND_ROUTING_KEY': '',
         'AMQP_DELIVERY_MODE': DeliveryMode.NONPERSISTENT,
     }


### PR DESCRIPTION
Add consumer/producer kwargs settings to be passed in as arguments when declaring inbound/outbound exchanges.