### PR TITLE
Update the Read the Docs domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Henson-AMQP |build status|
 
 A library for interacting with AMQP with a Henson application.
 
-* `Documentation <https://henson-amqp.rtfd.org>`_
-* `Installation <https://henson-amqp.readthedocs.org/en/latest/#installation>`_
-* `Changelog <https://henson-amqp.readthedocs.org/en/latest/changes.html>`_
+* `Documentation <https://henson-amqp.readthedocs.io>`_
+* `Installation <https://henson-amqp.readthedocs.io/en/latest/#installation>`_
+* `Changelog <https://henson-amqp.readthedocs.io/en/latest/changes.html>`_
 * `Source <https://github.com/iheartradio/Henson-AMQP>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,5 +295,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),
-    'amqp': ('http://aioamqp.readthedocs.org/en/latest/', None),
+    'amqp': ('https://aioamqp.readthedocs.io/en/latest/', None),
 }

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     version='0.6.0',
     author='Andy Dirnberger, Jon Banafato, and others',
     author_email='henson@iheart.com',
-    url='https://henson-amqp.rtfd.org',
+    url='https://henson-amqp.readthedocs.io',
     description='A library for interacting with AMQP with a Henson application.',
     long_description=read('README.rst'),
     license='Apache License, Version 2.0',


### PR DESCRIPTION
Read the Docs has switched from using readthedocs.org to readthedocs.io
for project documentation. It includes the added benefit of having
better HTTPS support.