### PR TITLE
Stop declaring the exchange with every message sent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Version 0.6.0
 
 Release TBD
 
+- Stop declaring the exchange with every message sent
+
 
 Version 0.5.0
 =============


### PR DESCRIPTION
Currently, Henson-AMQP's `Producer` class declares its destination
exchange every time it sends a message. This is needless work, so stop
doing it.