### PR TITLE
Remove 3.4 Support, Add 3.6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 # Use Python
 language: python
 
-# Run the test runner using the same version of Python we use.
-python: 3.5
+matrix:
+  include:
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=py36
+    - python: 3.6
+      env: TOX_ENV=docs
+    - python: 3.6
+      env: TOX_ENV=pep8
 
 # Use rabbitmq during tests
 services:
@@ -10,15 +18,7 @@ services:
 
 # Install the test runner.
 install: pip install tox
-
-# Run each environment separately so we get errors back from all of them.
-env:
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=pep8
-  - TOX_ENV=docs
-script:
-  - tox -e $TOX_ENV
+script: tox -e $TOX_ENV
 
 # Control the branches that get built.
 branches:

--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -159,6 +159,7 @@ class Consumer:
         Raises:
             aioamqp.exceptions.AioamqpException: The exception raised on
                 connection close.
+
         """
         # On the first call to read, connect to the AMQP server and
         # begin consuming messages.
@@ -348,6 +349,7 @@ class AMQP(Extension):
             Consumer: A new consumer object that can be used to read
                 from the AMQP broker and queue specified the
                 Application's settings.
+
         """
         return Consumer(self.app)
 
@@ -358,6 +360,7 @@ class AMQP(Extension):
             Producer: A new producer object that can be used to write to
                 the AMQP broker and exchange specified by the
                 Application's settings.
+
         """
         if not hasattr(self, '_producer'):
             self._producer = Producer(self.app)

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py34,py35
+envlist = docs,pep8,py35,py36
 
 [testenv]
 deps =
@@ -12,14 +12,14 @@ commands =
     python -m coverage report -m --include="henson_amqp/*"
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.6
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles --max-line-length 100 README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3.6
 deps =
     flake8-docstrings
     pep8-naming


### PR DESCRIPTION
`async` keyword was added in Python 3.5, so scrap support for 3.4, also add in support for 3.6.