### PR TITLE
Support Int and Enum For Delivery Mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Version 0.6.0
 
 Release TBD
 
+- Support both ``int`` values and existing ``henson_amqp.DeliveryMode`` ``enums``
+  for the ``AMQP_DELIVERY_MODE`` setting
 - Stop declaring the exchange with every message sent
 
 

--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -269,8 +269,9 @@ class Producer:
                 be used. Defaults to ``None``.
         """
         properties = {
-            'delivery_mode': self.app.settings['AMQP_DELIVERY_MODE'].value,
+            'delivery_mode': self.app.settings['AMQP_DELIVERY_MODE'],
         }
+
         if not self._channel:
             yield from self._connect()
             yield from self._declare_exchange()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ from henson_amqp import DeliveryMode
 
 
 @pytest.mark.parametrize(
-    'delivery_mode', (DeliveryMode.NONPERSISTENT, DeliveryMode.PERSISTENT))
+    'delivery_mode', (DeliveryMode.NONPERSISTENT, DeliveryMode.PERSISTENT, 1, 2))
 @pytest.mark.asyncio
 def test_read_write(test_consumer, test_producer, delivery_mode):
     """Test that reading from the consumer returns a message from amqp."""


### PR DESCRIPTION
We want to allow users of this extension to be able to pass in both `int` values, as well as continue to make use of the `henson_amqp.DeliveryMode` `enums` when using the `AMQP_DELIVERY_MODE` setting.

Currently, the underlying library, `aioamqp`, gets passed this setting (as an `IntEnum`) in a `properties` dictionary:

```
         properties = {
            'delivery_mode': self.app.settings['AMQP_DELIVERY_MODE'].value,
         }
```
As it turns out, `aioamqp` does not need the explicitly conversion of the `IntEnum` -> `int` via the `.value` property. You can just pass in the `IntEnum` and it handles it under the hood.

Removing this conversion allows `AMQP_DELIVERY_MODE` to be set as an `int`.