### PR TITLE
Add support for specifiying exchange with send

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 0.7.0
+=============
+
+Released 2019-02-20
+
+- Allow callers of ``Producer.send`` to specify an exchange name
+
+
 Version 0.6.0
 =============
 

--- a/henson_amqp/__init__.py
+++ b/henson_amqp/__init__.py
@@ -258,7 +258,7 @@ class Producer:
             self._transport.close()
 
     @asyncio.coroutine
-    def send(self, message, *, routing_key=None):
+    def send(self, message, *, exchange_name=None, routing_key=None):
         """Send a message to the configured AMQP broker and exchange.
 
         Args:
@@ -276,11 +276,14 @@ class Producer:
             yield from self._connect()
             yield from self._declare_exchange()
 
+        if exchange_name is None:
+            exchange_name = self.app.settings['AMQP_OUTBOUND_EXCHANGE']
         if routing_key is None:
             routing_key = self.app.settings['AMQP_OUTBOUND_ROUTING_KEY']
+
         yield from self._channel.publish(
             payload=message,
-            exchange_name=self.app.settings['AMQP_OUTBOUND_EXCHANGE'],
+            exchange_name=exchange_name,
             routing_key=routing_key,
             properties=properties,
         )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(filename):
 
 setup(
     name='Henson-AMQP',
-    version='0.6.0',
+    version='0.7.0',
     author='Andy Dirnberger, Jon Banafato, and others',
     author_email='henson@iheart.com',
     url='https://henson-amqp.readthedocs.io',

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -63,6 +63,37 @@ def test_retry(test_consumer):
 
 
 @pytest.mark.asyncio
+def test_produce_exhange_name(test_producer):
+    """Test that providing an exchange name works when sending."""
+    test_producer._channel = mock.MagicMock()
+    message = 'message acknowledged'
+    exchange_name = 'diverted'
+
+    yield from test_producer.send(message, exchange_name=exchange_name)
+    test_producer._channel.publish.assert_called_with(
+        payload=message,
+        routing_key=mock.ANY,
+        exchange_name=exchange_name,
+        properties=mock.ANY,
+    )
+
+
+@pytest.mark.asyncio
+def test_produce_no_exchange_name(test_producer):
+    """Test that the default exchange is used when none is provided."""
+    test_producer._channel = mock.MagicMock()
+    message = 'message acknowledged'
+    yield from test_producer.send(message)
+
+    test_producer._channel.publish.assert_called_with(
+        payload=message,
+        routing_key=mock.ANY,
+        exchange_name=test_producer.app.settings['AMQP_OUTBOUND_EXCHANGE'],
+        properties=mock.ANY,
+    )
+
+
+@pytest.mark.asyncio
 def test_produce_routing_key(test_producer):
     """Test that providing a routing key when sending works."""
     test_producer._channel = mock.MagicMock()


### PR DESCRIPTION
Currently all messages sent via henson-amqp use the default
outbound exchange from the app settings to send a message to.
This change allows for specifiying the exhange we would like to
send a message to, similar to the routing_key change prior.

This also bumps up the version from 0.6.0 to 0.7.0.