### PR TITLE
add-rabbit-prefetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 # Use Python
 language: python
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=1.0.0,<2.0.0',
-        'aioamqp>=0.5.1,<1.0.0',
+        'aioamqp>=0.5.1,<1.0.0,!=0.14.0',
     ],
     tests_require=[
         'pytest',

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -13,6 +13,8 @@ from henson_amqp import AMQP, Consumer, Message
 def test_register_consumer(test_app):
     """Test that consumer registration behaves correctly."""
     test_app.settings['REGISTER_CONSUMER'] = True
+    test_app.settings['AMQP_PREFETCH_COUNT'] = 1
+    test_app.settings['AMQP_PREFETCH_SIZE'] = 1
     AMQP(test_app)
     assert isinstance(test_app.consumer, Consumer)
 


### PR DESCRIPTION
This PR:

1. Adds support for rabbit consumer prefetch
2. Cleans up lint errors
3. Specifies travis `dist: trusty`
4. Skips aioamqp version 0.14.0

[3]
Since the last passing build of this repo, the travis default dist has changed from `trusty` to `xenial`, which doesn't have rabbitmq available. 

https://travis-ci.community/t/is-rabbitmq-service-down/4362/2

[4]
Version 0.14.0 is causing an issue with running pep in travis. Tox passes locally, so we've opted to skip this version.

https://travis-ci.org/iheartradio/Henson-AMQP/jobs/622842203?utm_medium=notification&utm_source=github_status