### PR TITLE
Update To Python 3.8 and 3.9, drop support for everything below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
-dist: trusty
+dist: xenial
 
-# Use Python
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
+
 language: python
 
 matrix:
   include:
-    - python: 3.5
-      env: TOX_ENV=py35
-    - python: 3.6
-      env: TOX_ENV=py36
-    - python: 3.6
+    - python: 3.8
+      env: TOX_ENV=py38
+    - python: 3.9
+      env: TOX_ENV=py39
+    - python: 3.9
       env: TOX_ENV=docs
-    - python: 3.6
+    - python: 3.9
       env: TOX_ENV=pep8
-
-# Use rabbitmq during tests
-services:
-  - rabbitmq
 
 # Install the test runner.
 install: pip install tox

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(filename):
 
 setup(
     name='Henson-AMQP',
-    version='0.8.1',
+    version='0.9.0',
     author='Leonard Bedner, Christian Paul, and others',
     author_email='henson@iheart.com',
     url='https://henson-amqp.readthedocs.io',
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=1.0.0,<3.0.0',
-        'aioamqp>=0.5.1,<1.0.0,!=0.14.0',
+        'aioamqp>=0.5.1,<1.0.0',
     ],
     tests_require=[
         'pytest',
@@ -47,8 +47,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -4,15 +4,15 @@ import pytest
 
 
 @pytest.mark.asyncio
-def test_disconnect_consumer(test_consumer):
+async def test_disconnect_consumer(test_consumer):
     """Test disconnect logic for consumers."""
     test_consumer._message_queue = asyncio.Queue()
     test_consumer._message_queue.put_nowait('message')
     test_consumer._message_queue.put_nowait('message')
     test_consumer._message_queue.put_nowait('message')
-    yield from test_consumer._connection_error_callback(Exception())
+    await test_consumer._connection_error_callback(Exception())
     for i in range(3):
-        message = yield from test_consumer.read()
+        message = await test_consumer.read()
         assert message == 'message'
     with pytest.raises(Exception):
-        yield from test_consumer.read()
+        await test_consumer.read()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,18 +10,18 @@ from henson_amqp import DeliveryMode
 @pytest.mark.parametrize(
     'delivery_mode', (DeliveryMode.NONPERSISTENT, DeliveryMode.PERSISTENT, 1, 2))
 @pytest.mark.asyncio
-def test_read_write(test_consumer, test_producer, delivery_mode):
+async def test_read_write(test_consumer, test_producer, delivery_mode):
     """Test that reading from the consumer returns a message from amqp."""
-    yield from test_consumer._begin_consuming()
+    await test_consumer._begin_consuming()
     test_producer.app.settings['AMQP_DELIVERY_MODE'] = delivery_mode
     message = json.dumps({'spam': 'eggs'}).encode()
-    yield from test_producer.send(message)
-    read_message = (yield from test_consumer.read())
-    yield from test_consumer._acknowledge_message(
+    await test_producer.send(message)
+    read_message = (await test_consumer.read())
+    await test_consumer._acknowledge_message(
         test_consumer.app,
         read_message,
     )
     assert read_message.body == message
     assert read_message.properties.delivery_mode == delivery_mode
-    yield from test_consumer._teardown(test_consumer.app)
-    yield from test_producer._teardown(test_producer.app)
+    await test_consumer._teardown(test_consumer.app)
+    await test_producer._teardown(test_producer.app)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -26,12 +26,12 @@ def test_no_register_consumer(test_app):
 
 
 @pytest.mark.asyncio
-def test_enqueue_message(test_consumer, test_envelope, test_properties):
+async def test_enqueue_message(test_consumer, test_envelope, test_properties):
     """Test adding messages to the consumer's message queue."""
     # Mock away the channel for unit tests
     test_consumer.channel = mock.MagicMock()
     test_consumer._message_queue = asyncio.Queue()
-    yield from test_consumer._enqueue_message(
+    await test_consumer._enqueue_message(
         test_consumer.channel, b'test', test_envelope, test_properties)
     expected_message = Message(b'test', test_envelope, test_properties)
     actual_message = test_consumer._message_queue.get_nowait()
@@ -39,7 +39,7 @@ def test_enqueue_message(test_consumer, test_envelope, test_properties):
 
 
 @pytest.mark.asyncio
-def test_read(test_consumer, test_envelope, test_properties):
+async def test_read(test_consumer, test_envelope, test_properties):
     """Test that reading returns a message from the queue."""
     # Mock away the channel for unit tests
     test_consumer._channel = mock.MagicMock()
@@ -47,16 +47,16 @@ def test_read(test_consumer, test_envelope, test_properties):
     # Get a consumer and add an mock message to its queue
     message = Message(b'foo', test_envelope, test_properties)
     test_consumer._message_queue.put_nowait(message)
-    read_message = (yield from test_consumer.read())
+    read_message = (await test_consumer.read())
     assert read_message == message
 
 
 @pytest.mark.asyncio
-def test_retry(test_consumer):
+async def test_retry(test_consumer):
     """Test that the included retry function works."""
-    test_consumer._channel = mock.MagicMock()
+    test_consumer._channel = mock.AsyncMock()
     message = {"spam": "eggs"}
-    yield from test_consumer.retry(test_consumer.app, message)
+    await test_consumer.retry(test_consumer.app, message)
     test_consumer._channel.publish.assert_called_with(
         payload=json.dumps(message).encode('utf-8'),
         exchange_name=test_consumer.app.settings['AMQP_INBOUND_EXCHANGE'],
@@ -65,13 +65,13 @@ def test_retry(test_consumer):
 
 
 @pytest.mark.asyncio
-def test_produce_exhange_name(test_producer):
+async def test_produce_exhange_name(test_producer):
     """Test that providing an exchange name works when sending."""
-    test_producer._channel = mock.MagicMock()
+    test_producer._channel = mock.AsyncMock()
     message = 'message acknowledged'
     exchange_name = 'diverted'
 
-    yield from test_producer.send(message, exchange_name=exchange_name)
+    await test_producer.send(message, exchange_name=exchange_name)
     test_producer._channel.publish.assert_called_with(
         payload=message,
         routing_key=mock.ANY,
@@ -81,11 +81,11 @@ def test_produce_exhange_name(test_producer):
 
 
 @pytest.mark.asyncio
-def test_produce_no_exchange_name(test_producer):
+async def test_produce_no_exchange_name(test_producer):
     """Test that the default exchange is used when none is provided."""
-    test_producer._channel = mock.MagicMock()
+    test_producer._channel = mock.AsyncMock()
     message = 'message acknowledged'
-    yield from test_producer.send(message)
+    await test_producer.send(message)
 
     test_producer._channel.publish.assert_called_with(
         payload=message,
@@ -96,13 +96,13 @@ def test_produce_no_exchange_name(test_producer):
 
 
 @pytest.mark.asyncio
-def test_produce_routing_key(test_producer):
+async def test_produce_routing_key(test_producer):
     """Test that providing a routing key when sending works."""
-    test_producer._channel = mock.MagicMock()
+    test_producer._channel = mock.AsyncMock()
     message = 'spam and eggs'
     routing_key = 'parrot'
 
-    yield from test_producer.send(message, routing_key=routing_key)
+    await test_producer.send(message, routing_key=routing_key)
     test_producer._channel.publish.assert_called_with(
         payload=message,
         routing_key=routing_key,
@@ -112,11 +112,11 @@ def test_produce_routing_key(test_producer):
 
 
 @pytest.mark.asyncio
-def test_produce_no_routing_key(test_producer):
+async def test_produce_no_routing_key(test_producer):
     """Test that a default routing key is used when none is provided."""
-    test_producer._channel = mock.MagicMock()
+    test_producer._channel = mock.AsyncMock()
     message = 'spam and eggs'
-    yield from test_producer.send(message)
+    await test_producer.send(message)
 
     test_producer._channel.publish.assert_called_with(
         payload=message,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py35,py36
+envlist = docs,pep8,py38,py39
 
 [testenv]
 deps =
@@ -8,18 +8,18 @@ deps =
     pytest-asyncio
 passenv = TEST_* PYTHONASYNCIODEBUG
 commands =
-    python -m coverage run -m pytest --strict {posargs: tests}
+    python -m coverage run -m pytest --strict-markers {posargs: tests}
     python -m coverage report -m --include="henson_amqp/*"
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.9
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles --max-line-length 100 README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3.9
 deps =
     flake8-docstrings
     pep8-naming


### PR DESCRIPTION
- remove support for Python <= 3.7
- add support for Python >= 3.8
- stopped using `@asyncio.coroutine`, added `async` to all appropriate methods, since the former is deprecated
- replaced `yield from` -> `await` where applicable, since the former is deprecated
- removed a block on `aioamqp==0.14.0`
- swapped `mock.MagicMock` -> `mock.AsyncMock` when using `await`
- changed `travis` distribution to `xenial` since `trusty` doesn't support Python 3.8 or higher
- since the `rabbitmq` service was a part of the `trusty` distribution, just install as an addon after server is built